### PR TITLE
Fix Books New Page Padding

### DIFF
--- a/app/assets/stylesheets/books.scss
+++ b/app/assets/stylesheets/books.scss
@@ -57,7 +57,6 @@
 .books__new {
   background-color: #dcdcdc;
   color: #282d33;
-  padding-bottom: calc(100% - 90px);
   .books__new__post {
     text-align: center;
     margin: 40px 0 20px;


### PR DESCRIPTION
# What
booksの新規作成ページの余白が多すぎるので狭める

# Why
長いページになってしまうため

# How
CSSでpaddingを指定する